### PR TITLE
Configure smtpd.conf for SASL and add an postfix_sasldb_user LWRP

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -87,3 +87,23 @@ suites:
         relayhost:
           username: "kitchenuser"
           password: "not-a-real-thing"
+
+- name: sasldb
+  run_list:
+  - recipe[postfix::server]
+  - recipe[postfix::sasldb]
+  attributes:
+    postfix:
+      sasl_conf:
+        pwcheck_method: auxprop
+        auxprop_plugin: sasldb
+        mech_list:
+          - PLAIN
+          - LOGIN
+          - CRAM-MD5
+          - DIGEST-MD5
+      sasldb:
+        users:
+          joe@example.com: foobarbaz
+          bob@example.com: bazbarfoo
+        group: mail

--- a/README.md
+++ b/README.md
@@ -276,8 +276,6 @@ Manage `/etc/postfix/virtual` with this recipe.
 
 Manage `/etc/postfix/relay_restriction` with this recipe The postfix option smtpd_relay_restrictions in main.cf will point to this hash map db.
 
-<http://wiki.chef.io/display/chef/Templates#Templates-TemplateLocationSpecificity>
-
 ## Usage
 
 On systems that should simply send mail directly to a relay, or out to the internet, use `recipe[postfix]` and modify the `node['postfix']['main']['relayhost']` attribute via a role.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ Includes the default recipe to install, configure and start postfix.
 
 Does not work with `chef-solo`.
 
+### sasl_common
+
+Installs the Cyrus SASL packages and configures `smtpd.conf` for authenticating mail clients. Included by the `sasldb` and `sasl_auth` recipes. You should manually include this before using the `postfix_sasldb_user` LWRP.
+
+### sasldb
+
+Creates SASL users with the `postfix_sasldb_user` LWRP from attributes containing email/password pairs.
+
 ### sasl_auth
 
 Sets up the system to authenticate with a remote mail relay using SASL authentication.
@@ -275,6 +283,23 @@ Manage `/etc/postfix/virtual` with this recipe.
 ### relay_restrictions
 
 Manage `/etc/postfix/relay_restriction` with this recipe The postfix option smtpd_relay_restrictions in main.cf will point to this hash map db.
+
+## LWRPs
+
+### postfix_sasldb_user
+
+Creates or disables a SASL user with the given email address and password in a flat BerkDB database using saslpasswd2. Make sure you include the `sasl_common` recipe first to install the required packages and configure `smtpd.conf`. Note that the default configuration will not use this database. Set the following attributes to use it.
+
+```ruby
+override_attributes(
+  "postfix" => {
+    "sasl_conf" => {
+      "pwcheck_method" => "auxprop",
+      "auxprop_plugin" => "sasldb"
+    }
+  }
+)
+```
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # Author:: Joshua Timberman <joshua@chef.io>
-# Copyright:: 2009-2017, Chef Software, Inc.
+# Copyright:: 2009-2018, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -378,6 +378,15 @@ default['postfix']['master']['bsmtp']['unpriv'] = false
 default['postfix']['master']['bsmtp']['chroot'] = false
 default['postfix']['master']['bsmtp']['command'] = 'pipe'
 default['postfix']['master']['bsmtp']['args'] = ['flags=Fq. user=foo argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient']
+
+# SASL smtpd.conf attributes
+default['postfix']['sasl_conf']['pwcheck_method'] = 'saslauthd'
+default['postfix']['sasl_conf']['mech_list'] = %w(plain login)
+
+# sasldb attributes
+default['postfix']['sasldb']['users'] = {}
+default['postfix']['sasldb']['group'] = 'postfix'
+default['postfix']['sasldb']['path'] = '/etc/sasldb2'
 
 # OS Aliases
 default['postfix']['aliases'] = case node['platform']

--- a/libraries/provider_postfix_sasldb_user.rb
+++ b/libraries/provider_postfix_sasldb_user.rb
@@ -1,0 +1,63 @@
+#
+# Cookbook Name:: postfix
+# Provider:: sasldb_user
+#
+
+require 'chef/provider/lwrp_base'
+require 'chef/mixin/shell_out'
+
+class Chef
+  class Provider
+    class PostfixSasldbUser < Chef::Provider::LWRPBase
+      include Chef::Mixin::ShellOut
+
+      provides :postfix_sasldb_user
+      use_inline_resources
+
+      def whyrun_supported?
+        true
+      end
+
+      def load_current_resource
+        @current_resource = Chef::Resource::PostfixSasldbUser.new(@new_resource.name)
+
+        cmd = Mixlib::ShellOut.new("sasldblistusers2 | grep '^#{@current_resource.email}: '")
+        cmd.run_command
+
+        @current_resource.exists = true unless cmd.error?
+        @current_resource
+      end
+
+      action :create do
+        return if current_resource.exists?
+
+        converge_by 'saslpasswd2 -c' do
+          shell_out!('saslpasswd2', '-c', '-p', '-u', new_resource.domain, new_resource.username, input: new_resource.password)
+        end
+
+        set_permissions
+      end
+
+      action :disable do
+        return unless current_resource.exists?
+
+        converge_by 'saslpasswd2 -d' do
+          shell_out!('saslpasswd2', '-d', '-u', current_resource.domain, current_resource.username)
+        end
+
+        set_permissions
+      end
+
+      def set_permissions
+        file "sasldb permissions for #{@new_resource.name}" do
+          path node['postfix']['sasldb']['path']
+          owner 'root'
+          group node['postfix']['sasldb']['group']
+          mode '0640'
+          action :touch
+          only_if { ::File.exist? path }
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_postfix_sasldb_user.rb
+++ b/libraries/resource_postfix_sasldb_user.rb
@@ -1,0 +1,34 @@
+#
+# Cookbook Name:: postfix
+# Resource:: sasldb_user
+#
+
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class PostfixSasldbUser < Chef::Resource::LWRPBase
+      resource_name :postfix_sasldb_user
+
+      attr_reader :username, :domain
+      attr_writer :exists
+
+      attribute :email, kind_of: String, name_attribute: true, regex: /\A[^@]+@[^@]+\Z/
+      attribute :password, kind_of: String
+
+      actions :create, :disable
+      default_action :create
+
+      def initialize(name, run_context = nil)
+        super
+
+        @username, @domain = email.split('@')
+        @exists = false
+      end
+
+      def exists?
+        @exists
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,9 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '5.3.1'
 
 recipe 'postfix', 'Installs and configures postfix'
-recipe 'postfix::sasl_auth', 'Set up postfix to auth to a server with sasl'
+recipe 'postfix::sasl_common', 'Installs the SASL packages and configures smtpd.conf'
+recipe 'postfix::sasldb', 'Creates SASL users from attributes'
+recipe 'postfix::sasl_auth', 'Sets up Postfix to auth to a server with SASL'
 recipe 'postfix::aliases', 'Manages /etc/aliases'
 recipe 'postfix::transports', 'Manages /etc/postfix/transport'
 recipe 'postfix::access', 'Manages /etc/postfix/access'

--- a/recipes/sasl_auth.rb
+++ b/recipes/sasl_auth.rb
@@ -3,7 +3,7 @@
 # Cookbook:: postfix
 # Recipe:: sasl_auth
 #
-# Copyright:: 2009-2017, Chef Software, Inc.
+# Copyright:: 2009-2018, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,29 +19,7 @@
 #
 
 include_recipe 'postfix::_common'
-
-sasl_pkgs = []
-
-# We use case instead of value_for_platform_family because we need
-# version specifics for RHEL.
-case node['platform_family']
-when 'debian'
-  sasl_pkgs = %w(libsasl2-2 libsasl2-modules ca-certificates)
-when 'rhel'
-  sasl_pkgs = if node['platform_version'].to_i < 6
-                %w(cyrus-sasl cyrus-sasl-plain openssl)
-              else
-                %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
-              end
-when 'amazon'
-  sasl_pkgs = %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
-when 'fedora'
-  sasl_pkgs = %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
-end
-
-sasl_pkgs.each do |pkg|
-  package pkg
-end
+include_recipe 'postfix::sasl_common'
 
 execute 'postmap-sasl_passwd' do
   command "postmap #{node['postfix']['sasl_password_file']}"

--- a/recipes/sasl_common.rb
+++ b/recipes/sasl_common.rb
@@ -1,0 +1,57 @@
+# Author:: Joshua Timberman(<joshua@chef.io>)
+# Cookbook Name:: postfix
+# Recipe:: sasl_common
+#
+# Copyright 2009-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sasl_pkgs = []
+
+# We use case instead of value_for_platform_family because we need
+# version specifics for RHEL.
+case node['platform_family']
+when 'debian'
+  sasl_pkgs = %w(libsasl2-2 libsasl2-modules ca-certificates sasl2-bin)
+when 'rhel'
+  sasl_pkgs = if node['platform_version'].to_i < 6
+                %w(cyrus-sasl cyrus-sasl-plain openssl)
+              else
+                %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
+              end
+when 'amazon', 'fedora'
+  sasl_pkgs = %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
+end
+
+sasl_pkgs.each do |pkg|
+  package pkg
+end
+
+default_cyrus_sasl = "/etc/sasl#{2 unless platform_family? 'omnios', 'smartos'}"
+cyrus_sasl = node['postfix']['main']['cyrus_sasl_config_path'] || default_cyrus_sasl
+smtpd = node['postfix']['main']['smtpd_sasl_path'] || 'smtpd'
+
+directory cyrus_sasl do
+  owner 'root'
+  group node['root_group']
+  mode '0755'
+end
+
+template "#{cyrus_sasl}/#{smtpd}.conf" do
+  source 'sasl.conf.erb'
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+  variables(settings: node['postfix']['sasl_conf'])
+end

--- a/recipes/sasldb.rb
+++ b/recipes/sasldb.rb
@@ -1,0 +1,28 @@
+#
+# Author:: James Le Cuirot(<james.le-cuirot@yakara.com>)
+# Cookbook Name:: postfix
+# Recipe:: sasldb
+#
+# Copyright 2009-2018, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'postfix::_common'
+include_recipe 'postfix::sasl_common'
+
+node['postfix']['sasldb']['users'].each do |email, password|
+  postfix_sasldb_user email do
+    password password
+  end
+end

--- a/templates/default/sasl.conf.erb
+++ b/templates/default/sasl.conf.erb
@@ -1,0 +1,3 @@
+<%- for key, value in @settings -%>
+<%= key %>: <%= [*value].join(' ') %>
+<%- end -%>


### PR DESCRIPTION
This allows Postfix to authenticate clients using SASL, using either a sasldb file or saslauthd. The presence of the existing sasl_auth recipe for using SASL as a client makes the situation a little confusing. Perhaps a less ambiguous name would have helped.

It was tricky to figure out where smtpd.conf should be configured. CentOS installs it along with Postfix itself but other platforms don't seem to install it at all. It's not much use without the SASL packages so I lumped it into the new sasl_common recipe. It does no harm to those not wanting to authenticate clients with SASL.

The default attributes for configuring smtpd.conf mirror the CentOS defaults, which is to use PLAIN or LOGIN against saslauthd, which in turn uses PAM. These seem like good defaults.

The sasldb recipe was added primarily for testing as most will probably want to use the LWRP directly in conjunction with encrypted data bags or something but it may be useful to someone. :smile: 
