### PR TITLE
Move the config template write to the first actions to be done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the postfix cookbook.
 
 ## Unreleased
 
-- postfix package assumes ipv6 is always available, however this is not always true. In order to tell postmap this is the case the configs need to be written first
+- Make sure we write the main.conf and master.conf before we try to use any commands (like postmap)
 
 ## 6.0.1 - *2021-06-01*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the postfix cookbook.
 
 ## Unreleased
 
+- postfix package assumes ipv6 is always available, however this is not always true. In order to tell postmap this is the case the configs need to be written first
+
 ## 6.0.1 - *2021-06-01*
 
 ## 6.0.0 - *2020-11-23*


### PR DESCRIPTION
# Description

The postfix config is written before we try to execute postfix commands (like postmap)

## Issues Resolved

With this change setting inet_interfaces to ipv4 works and commands will work on ipv6 disabled environments.
