### PR TITLE
Update tested platforms

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,0 @@
-[local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,34 +8,11 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: 'lint-unit'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,17 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'almalinux-8'
           - 'amazonlinux-2'
-          - 'debian-9'
-          - 'debian-10'
           - 'centos-7'
-          - 'centos-8'
+          - 'centos-stream-8'
+          - 'debian-10'
+          - 'debian-11'
           - 'fedora-latest'
-          - 'ubuntu-1604'
+          - 'opensuse-leap-15'
+          - 'rockylinux-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
-          - 'opensuse-leap-15'
         suite:
           - 'default'
           - 'aliases'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the postfix cookbook.
 
 ## Unreleased
 
+- Update tested platforms
+
 ## 6.0.5 - *2022-01-08*
 
 - resolved cookstyle error: test/integration/helpers/serverspec/spec_helper.rb:9:21 convention: `Style/FileRead`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the postfix cookbook.
 ## Unreleased
 
 - Update tested platforms
+- Remove delivery and move to calling RSpec directly via a reusable workflow
 
 ## 6.0.5 - *2022-01-08*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -12,19 +12,24 @@ provisioner:
   name: dokken
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
   - name: debian-10
     driver:
       image: dokken/debian-10
+      pid_one_command: /bin/systemd
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
       pid_one_command: /bin/systemd
 
   - name: centos-7
@@ -32,20 +37,15 @@ platforms:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: ubuntu-16.04
-    driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /bin/systemd
 
   - name: ubuntu-18.04
     driver:
@@ -60,4 +60,9 @@ platforms:
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
       pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
@@ -13,14 +13,15 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
   - name: fedora-latest
   - name: opensuse-leap-15
-  - name: ubuntu-16.04
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -19,23 +19,9 @@ describe 'postfix::default' do
     end
   end
 
-  context 'on SmartOS' do
+  context 'on Ubuntu 20.04' do
     cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11').converge(described_recipe)
-    end
-
-    it '[COOK-4423] renders file main.cf without smtp_use_tls' do
-      expect(chef_run).to render_file('/opt/local/etc/postfix/main.cf').with_content(/smtp_use_tls += +no/)
-    end
-
-    it '[COOK-4619] does not set recipient_delimiter' do
-      expect(chef_run).to_not render_file('/etc/postfix/main.cf').with_content('recipient_delimiter')
-    end
-  end
-
-  context 'on Ubuntu 16.04' do
-    cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 16.04).converge(described_recipe)
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 20.04).converge(described_recipe)
     end
 
     it '[COOK-4423] renders file main.cf with /etc/postfix/cacert.pem' do


### PR DESCRIPTION
- Remove CentOS 8, Debian 9 & Ubuntu 16.04
- Add CentOS Stream 8, Alma Linux 8, Rocky Linux 8, Debian 11
- Remove SmartOS from ChefSpec as the platform will deprecated soon

Signed-off-by: Lance Albertson <lance@osuosl.org>
