### PR TITLE
add installation of postfix addon packages for RHEL 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the postfix cookbook.
 
 ## Unreleased
 
+- add installation of postfix addon packages for RHEL 8
+
 ## 6.0.21 - *2023-05-17*
 
 ## 6.0.20 - *2023-04-17*

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See `attributes/default.rb` for default values.
 - `node['postfix']['aliases']` - hash of aliases to create with `recipe[postfix::aliases]`, see below under **Recipes** for more information.
 - `node['postfix']['transports']` - hash of transports to create with `recipe[postfix::transports]`, see below under **Recipes** for more information.
 - `node['postfix']['access']` - hash of access to create with `recipe[postfix::access]`, see below under **Recipes** for more information.
-- `node['postfix']['virtual_aliases']` - hash of virtual_aliases to create with `recipe[postfix::virtual_aliases]`, see below under __Recipes__ for more information.
+- `node['postfix']['virtual_aliases']` - hash of virtual_aliases to create with `recipe[postfix::virtual_aliases]`, see below under **Recipes** for more information.
 - `node['postfix']['main_template_source']` - Cookbook source for main.cf template. Default 'postfix'
 - `node['postfix']['master_template_source']` - Cookbook source for master.cf template. Default 'postfix'
 

--- a/recipes/maps.rb
+++ b/recipes/maps.rb
@@ -17,6 +17,9 @@ node['postfix']['maps'].each do |type, maps|
   if platform_family?('debian')
     package "postfix-#{type}" if %w(pgsql mysql ldap cdb).include?(type)
   end
+  if platform?('redhat') && node['platform_version'].to_i == 8
+    package "postfix-#{type}" if %w(pgsql mysql ldap cdb).include?(type)
+  end
 
   separator = if %w(pgsql mysql ldap memcache sqlite).include?(type)
                 ' = '


### PR DESCRIPTION
RHEL 8 introduces modules and a lot of packages have been split up to have some of their not so often used parts in extra modules

# Description

Postfix maps utilizing pgsql, mysql, ldap or cdb do not work on RedHat Enterprise Linux 8. This change adds the necessary installation of the postfix addon packages on this platform.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
