### PR TITLE
Add support for AlmaLinux 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         os:
           - almalinux-8
           - almalinux-9
+          - almalinux-10
           - amazonlinux-2023
           - centos-stream-9
           - debian-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the postfix cookbook.
 
 ## Unreleased
 
+- Use LMDB instead of hash on el10
+
 ## Unreleased
 
 ## 6.2.2 - *2025-01-30*

--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -29,24 +29,24 @@ end
 
 if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
   node.default_unless['postfix']['sasl_password_file'] = "#{node['postfix']['conf_dir']}/sasl_passwd"
-  node.default_unless['postfix']['main']['smtp_sasl_password_maps'] = "hash:#{node['postfix']['sasl_password_file']}"
+  node.default_unless['postfix']['main']['smtp_sasl_password_maps'] = "#{node['postfix']['db_type']}:#{node['postfix']['sasl_password_file']}"
   node.default_unless['postfix']['main']['smtp_sasl_security_options'] = 'noanonymous'
   node.default_unless['postfix']['sasl']['smtp_sasl_user_name'] = ''
   node.default_unless['postfix']['sasl']['smtp_sasl_passwd']    = ''
   node.default_unless['postfix']['main']['relayhost'] = ''
 end
 
-node.default_unless['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"] if node['postfix']['use_alias_maps']
+node.default_unless['postfix']['main']['alias_maps'] = ["#{node['postfix']['db_type']}:#{node['postfix']['aliases_db']}"] if node['postfix']['use_alias_maps']
 
-node.default_unless['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"] if node['postfix']['use_transport_maps']
+node.default_unless['postfix']['main']['transport_maps'] = ["#{node['postfix']['db_type']}:#{node['postfix']['transport_db']}"] if node['postfix']['use_transport_maps']
 
-node.default_unless['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"] if node['postfix']['use_access_maps']
+node.default_unless['postfix']['main']['access_maps'] = ["#{node['postfix']['db_type']}:#{node['postfix']['access_db']}"] if node['postfix']['use_access_maps']
 
 node.default_unless['postfix']['main']['virtual_alias_maps'] = ["#{node['postfix']['virtual_alias_db_type']}:#{node['postfix']['virtual_alias_db']}"] if node['postfix']['use_virtual_aliases']
 
 node.default_unless['postfix']['main']['virtual_alias_domains'] = ["#{node['postfix']['virtual_alias_domains_db_type']}:#{node['postfix']['virtual_alias_domains_db']}"] if node['postfix']['use_virtual_aliases_domains']
 
-node.default_unless['postfix']['main']['smtpd_relay_restrictions'] = "hash:#{node['postfix']['relay_restrictions_db']}, reject" if node['postfix']['use_relay_restrictions_maps']
+node.default_unless['postfix']['main']['smtpd_relay_restrictions'] = "#{node['postfix']['db_type']}:#{node['postfix']['relay_restrictions_db']}, reject" if node['postfix']['use_relay_restrictions_maps']
 
 node.default_unless['postfix']['main']['maildrop_destination_recipient_limit'] = 1 if node['postfix']['master']['maildrop']['active']
 

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -155,7 +155,7 @@ unless node['postfix']['sender_canonical_map_entries'].empty?
     notifies :reload, 'service[postfix]'
   end
 
-  node.default['postfix']['main']['sender_canonical_maps'] = "hash:#{node['postfix']['conf_dir']}/sender_canonical" unless node['postfix']['main'].key?('sender_canonical_maps')
+  node.default['postfix']['main']['sender_canonical_maps'] = "#{node['postfix']['db_type']}:#{node['postfix']['conf_dir']}/sender_canonical" unless node['postfix']['main'].key?('sender_canonical_maps')
 end
 
 execute 'update-postfix-smtp_generic' do
@@ -172,7 +172,7 @@ unless node['postfix']['smtp_generic_map_entries'].empty?
     notifies :reload, 'service[postfix]'
   end
 
-  node.default['postfix']['main']['smtp_generic_maps'] = "hash:#{node['postfix']['conf_dir']}/smtp_generic" unless node['postfix']['main'].key?('smtp_generic_maps')
+  node.default['postfix']['main']['smtp_generic_maps'] = "#{node['postfix']['db_type']}:#{node['postfix']['conf_dir']}/smtp_generic" unless node['postfix']['main'].key?('smtp_generic_maps')
 end
 
 execute 'update-postfix-recipient_canonical' do
@@ -189,7 +189,7 @@ unless node['postfix']['recipient_canonical_map_entries'].empty?
     notifies :reload, 'service[postfix]'
   end
 
-  node.default['postfix']['main']['recipient_canonical_maps'] = "hash:#{node['postfix']['conf_dir']}/recipient_canonical" unless node['postfix']['main'].key?('recipient_canonical_maps')
+  node.default['postfix']['main']['recipient_canonical_maps'] = "#{node['postfix']['db_type']}:#{node['postfix']['conf_dir']}/recipient_canonical" unless node['postfix']['main'].key?('recipient_canonical_maps')
 end
 
 service 'postfix' do

--- a/recipes/maps.rb
+++ b/recipes/maps.rb
@@ -18,8 +18,8 @@ node['postfix']['maps'].each do |type, maps|
     package "postfix-#{type}" if %w(pgsql mysql ldap cdb).include?(type)
   end
 
-  if platform?('redhat') && node['platform_version'].to_i == 8
-    package "postfix-#{type}" if %w(pgsql mysql ldap cdb).include?(type)
+  if platform_family?('rhel') && node['platform_version'].to_i >= 8
+    package "postfix-#{type}" if %w(pgsql mysql ldap cdb lmdb).include?(type)
   end
 
   separator = if %w(pgsql mysql ldap memcache sqlite).include?(type)
@@ -32,7 +32,7 @@ node['postfix']['maps'].each do |type, maps|
       command "postmap #{file}"
       environment PATH: "#{ENV['PATH']}:/opt/omni/bin:/opt/omni/sbin" if platform_family?('omnios')
       action :nothing
-    end if %w(btree cdb dbm hash sdbm).include?(type)
+    end if %w(btree cdb dbm hash lmdb sdbm).include?(type)
     template "#{file}-#{type}" do
       path file
       source 'maps.erb'
@@ -41,7 +41,7 @@ node['postfix']['maps'].each do |type, maps|
         map: content,
         separator: separator
       )
-      notifies :run, "execute[update-postmap-#{file}]" if %w(btree cdb dbm hash sdbm).include?(type)
+      notifies :run, "execute[update-postmap-#{file}]" if %w(btree cdb dbm hash lmdb sdbm).include?(type)
       notifies :restart, 'service[postfix]'
     end
   end

--- a/test/integration/canonical/controls/canonical.rb
+++ b/test/integration/canonical/controls/canonical.rb
@@ -2,6 +2,12 @@ recipient_canonical =
   case os.family
   when 'suse'
     '/etc/postfix/recipient_canonical.lmdb'
+  when 'redhat'
+    if os.release.to_i >= 10
+      '/etc/postfix/recipient_canonical'
+    else
+      '/etc/postfix/recipient_canonical.db'
+    end
   else
     '/etc/postfix/recipient_canonical.db'
   end

--- a/test/integration/sasl_auth_multiple/controls/sasl_auth_multiple.rb
+++ b/test/integration/sasl_auth_multiple/controls/sasl_auth_multiple.rb
@@ -13,7 +13,9 @@ control 'sasl_auth_multiple' do
     end
   end
 
+  db_type = ((os.family == 'redhat' && os.release.to_i >= 10) || (os.family == 'suse' && os.release.to_i >= 15)) ? 'lmdb' : 'hash'
+
   describe postfix_conf '/etc/postfix/main.cf' do
-    its('smtp_sasl_password_maps') { should eq 'hash:/etc/postfix/sasl_passwd' }
+    its('smtp_sasl_password_maps') { should eq "#{db_type}:/etc/postfix/sasl_passwd" }
   end
 end

--- a/test/integration/sasl_auth_none/controls/sasl_auth_none.rb
+++ b/test/integration/sasl_auth_none/controls/sasl_auth_none.rb
@@ -11,7 +11,9 @@ control 'sasl_auth_none' do
     end
   end
 
+  db_type = ((os.family == 'redhat' && os.release.to_i >= 10) || (os.family == 'suse' && os.release.to_i >= 15)) ? 'lmdb' : 'hash'
+
   describe postfix_conf '/etc/postfix/main.cf' do
-    its('smtp_sasl_password_maps') { should eq 'hash:/etc/postfix/sasl_passwd' }
+    its('smtp_sasl_password_maps') { should eq "#{db_type}:/etc/postfix/sasl_passwd" }
   end
 end

--- a/test/integration/sasl_auth_one/controls/sasl_auth_one.rb
+++ b/test/integration/sasl_auth_one/controls/sasl_auth_one.rb
@@ -12,7 +12,9 @@ control 'sasl_auth_one' do
     end
   end
 
+  db_type = ((os.family == 'redhat' && os.release.to_i >= 10) || (os.family == 'suse' && os.release.to_i >= 15)) ? 'lmdb' : 'hash'
+
   describe postfix_conf '/etc/postfix/main.cf' do
-    its('smtp_sasl_password_maps') { should eq 'hash:/etc/postfix/sasl_passwd' }
+    its('smtp_sasl_password_maps') { should eq "#{db_type}:/etc/postfix/sasl_passwd" }
   end
 end


### PR DESCRIPTION
# Description

This change allows the cookbook to be used on AlmaLinux 10 which no longer compiles postfix with the hash dictionary type enabled.

## Issues Resolved

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
