### PR TITLE
fix: rebuild the alias database when /etc/aliases changes

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -113,7 +113,6 @@ action :create do
   postfix_map postfix_path(:aliases_db) do
     content(new_resource.aliases || postfix_aliases)
     template_source 'aliases.erb'
-    postmap false
     update_command 'newaliases'
   end if use_alias_maps
 

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -37,6 +37,11 @@ describe 'postfix resources' do
     it 'renders aliases through postfix_map' do
       expect(chef_run).to render_file('/etc/aliases').with_content(/^root: admin$/)
     end
+
+    it 'rebuilds the alias database when /etc/aliases changes' do
+      expect(chef_run.template('/etc/aliases')).to notify('execute[update-postfix-map-/etc/aliases]').to(:run).immediately
+      expect(chef_run.execute('update-postfix-map-/etc/aliases').command).to eq('newaliases')
+    end
   end
 
   context 'postfix_map' do

--- a/test/integration/aliases/controls/aliases.rb
+++ b/test/integration/aliases/controls/aliases.rb
@@ -1,3 +1,13 @@
+control 'aliases-db' do
+  # hash databases compile to .db, lmdb to .lmdb — pick whichever exists
+  aliases_db = %w(/etc/aliases.db /etc/aliases.lmdb).find { |f| file(f).exist? } || '/etc/aliases.db'
+
+  describe file aliases_db do
+    it { should exist }
+    its('mtime') { should be >= file('/etc/aliases').mtime }
+  end
+end
+
 control 'aliases' do
   describe file '/etc/aliases' do
     its('content') do


### PR DESCRIPTION
# Description

The aliases `postfix_map` in `resources/config.rb` was declared with `postmap false`, but `resources/map.rb` only declares the update execute — and only wires the template notification to it — when `postmap` is true. That made `update_command 'newaliases'` dead code: Chef rewrote `/etc/aliases` but never ran `newaliases`, so the compiled alias database went stale silently. Mail to newly added aliases bounces while converges look green (observed in production on a 7.0.x relay: `template[/etc/aliases]` updated, `newaliases` never ran — unlike transport/access/virtual/canonical, which each got their `update-postfix-map-*` execute).

This drops `postmap false` so the template rewrite notifies the execute, which now runs `newaliases`. Also:

- add a ChefSpec assertion on the notification wiring (template notifies `execute[update-postfix-map-/etc/aliases]` immediately, command is `newaliases`)
- add an `aliases-db` InSpec control asserting the compiled database (`.db`/`.lmdb`) exists and is at least as new as `/etc/aliases`

## Issues Resolved

None filed.

## Check List

- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] New functionality includes testing
- [x] New functionality has been documented in the README if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)